### PR TITLE
Added mac mojave compile support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ ext_modules = [
     CppExtension(
         "torch_complex.cpp",
         ["src/module.cpp"],
-        extra_compile_args=["-g"],
+        extra_compile_args=["-g", "-stdlib=libc++", "-std=c++11"],
     )
 ]
 


### PR DESCRIPTION
Fixed by referencing here:
https://github.com/geany/geany/issues/1618

> At the end I decided to add the -stdlib=libc++ -std=c++11 flags to make when building which means the deployment target doesn't have to be bumped to drastically but just to 10.7 where libc++ was introduced.
> 
> This has been committed to the geany-osx project so this one can be closed.